### PR TITLE
Fix script install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     author_email     = 'contact [at] deza.pe',
     version          = metadata['version'],
     url              = 'http://github.com/alfredodeza/wari',
-    scripts          = ['bin/wari'],
+    entry_points     = dict(console_scripts=['wari = wari.main:main']),
     license          = "MIT",
     zip_safe         = False,
     keywords         = "otp, one time password, cli, manager",

--- a/wari/main.py
+++ b/wari/main.py
@@ -58,3 +58,11 @@ totp                 Subcommand to interact with time based tokens (TOTP)
         parser.catches_help()
         parser.catches_version()
         conn.close()
+
+
+def main():
+    wari = Wari()
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Before this patch:

```
$ python setup.py install
<snip>
running build_scripts
error: file '/Users/zack/src/wari/bin/wari' does not exist
```

I wondered if maybe a file simply got left out of the repo by accident; this does seem to work though.
